### PR TITLE
Add missing dependency to fabric_nodes.

### DIFF
--- a/fabric_nodes/package.xml
+++ b/fabric_nodes/package.xml
@@ -21,6 +21,8 @@
   <depend>rclpy</depend>
   <depend>rclcpp_components</depend>
 
+  <exec_depend>python3-pandas</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ros_testing</test_depend>


### PR DESCRIPTION
`get_log.py` uses `pandas` which may not be installed by default.