### PR TITLE
Handful of Fixes

### DIFF
--- a/fabric_nodes/fabric_nodes/get_log.py
+++ b/fabric_nodes/fabric_nodes/get_log.py
@@ -135,13 +135,6 @@ class GetLog():
     # @brief Output the parsed statistics.
     #
     def output_log(self):
-        outlier_indices_neg = self.parsed_log_df[(
-                              self.parsed_log_df['ROS Layer Transmission Time'] <
-                              self.parsed_log_df['RMW Layer Transmission Time'])].index
-        outlier_indices_large = self.parsed_log_df[(
-                                self.parsed_log_df['ROS Layer Transmission Time'] -
-                                self.parsed_log_df['RMW Layer Transmission Time'] > 50000)].index
-        self.parsed_log_df.drop(outlier_indices_neg.union(outlier_indices_large), inplace=True)
         self.parsed_log_df.to_csv((
             str(round(self.time, 3)) + '-seconds-' +
             self.run_id+'_time_log.csv'), sep='\t', index=False)

--- a/fabric_nodes/fabric_nodes/get_log.py
+++ b/fabric_nodes/fabric_nodes/get_log.py
@@ -87,18 +87,6 @@ class GetLog():
         return [rmw_time, rmw_sub_time, rmw_pub_time]
 
     ##
-    # @brief Parse frequency and bandwidth logs and extract various information.
-    # @param [in] log A line from the log file.
-    # @return The extracted frequency and bandwidth log data as a list.
-    #
-    def search_freq_bw_log(self, log):
-        time_stamp = str(re.search(r'(?<=\[)\d*\.\d*(?=\])', log).group()) or None
-        topic_name = str(re.search(r'(?<=Topic:\s).*(?=,\sF)', log).group()) or None
-        topic_freq = str(re.search(r'(?<=Freq:\s)\d*\.\d*', log).group()) or None
-        topic_bw = str(re.search(r'(?<=Bandwidth:\s)\d*', log).group()) or None
-        return [time_stamp, topic_name, topic_freq, topic_bw]
-
-    ##
     # @brief Parse the entire log file to gather statistics.
     #
     def parse_log(self):

--- a/fabric_nodes/fabric_nodes/get_log.py
+++ b/fabric_nodes/fabric_nodes/get_log.py
@@ -18,16 +18,13 @@ import re
 
 import numpy as np
 import pandas as pd
-import rclpy
-
-from rclpy.node import Node
 
 
 ##
 # @class GetLog.
 # @brief Gather statistics from log files for a given period or run.
 #
-class GetLog(Node):
+class GetLog():
 
     ##
     # @brief The contructor for GetLog.
@@ -36,7 +33,6 @@ class GetLog(Node):
     # @param [in] run_id ID for a specific run.
     #
     def __init__(self, time=0, dds='rmw_cyclonedds', run_id='default_run'):
-        super().__init__('get_log')
         ## Logging duration in nanoseconds.
         self.time = time
         ## Data Distribution Service middleware that was operated.
@@ -56,7 +52,7 @@ class GetLog(Node):
         logfile_path = os.path.join(ros_log_dir, self.run_id, 'launch.log')
         ## The line that extracted from log.
         self.lines = open(logfile_path, 'r').readlines()
-        self.get_logger().info('Reading log from ' + logfile_path)
+        print('Reading log from ' + logfile_path)
 
     ##
     # @brief Parse ROS logs and extract various information.
@@ -116,7 +112,7 @@ class GetLog(Node):
         for line in self.lines:
             current_timestamp = float(re.search(r'\d*\.\d*(?=\s)', line).group())
             if (current_timestamp > begin_timestamp + self.time):
-                self.get_logger().info('Starting at ' + str(begin_timestamp) +
+                print('Starting at ' + str(begin_timestamp) +
                                        ', ending at ' + str(current_timestamp))
                 use_input_time = True
                 break
@@ -128,7 +124,7 @@ class GetLog(Node):
                     continue
                 parsed_log.append(self.search_ros_log(stats_log.group())+parsed_rmw)
         if (not use_input_time):
-            self.get_logger().info('This given log has less than ' + str(self.time) + ' seconds.')
+            print('This given log has less than ' + str(self.time) + ' seconds.')
             ## The time difference between the logger.
             self.time = current_timestamp - begin_timestamp
         ## The parsed Sub Time, Pub Time, and Trans Time in pd.DataFrame format.
@@ -161,7 +157,7 @@ class GetLog(Node):
         self.parsed_log_df.to_csv((
             str(round(self.time, 3)) + '-seconds-' +
             self.run_id+'_time_log.csv'), sep='\t', index=False)
-        self.get_logger().info(str(self.time) +
+        print(str(self.time) +
                                ' seconds on run: ' + self.run_id + ' with ' + self.dds)
 
         ## The xmt time of the ros layer.
@@ -182,21 +178,19 @@ class GetLog(Node):
         for gp in topics_groups.groups:
             self.each_topic_parsed_log_df.append(topics_groups.get_group(gp))
 
-        self.get_logger().info(
+        print(
             'Average ROS XMT is: ' + str(np.mean(self.ros_xmt_time)) + ' ns, ' +
             'with a standard deviation of ' + str(np.std(self.ros_xmt_time)) + ' ns.')
-        self.get_logger().info(
+        print(
             'Average RMW XMT is: ' + str(np.mean(self.rmw_xmt_time)) + ' ns, ' +
             'with a standard deviation of ' + str(np.std(self.rmw_xmt_time)) + ' ns.')
 
 
 def main(args=None):
-    rclpy.init(args=args)
     m_log = GetLog(60, 'rmw_cyclonedds')
     m_log.read_log()
     m_log.parse_log()
     m_log.output_log()
-    rclpy.shutdown()
 
 
 if __name__ == '__main__':

--- a/fabric_nodes/src/dummy_node.cpp
+++ b/fabric_nodes/src/dummy_node.cpp
@@ -373,7 +373,7 @@ void DummyNode::sub_callback(
   // Calculate Recieve Rate
   if (msg->seq_num != seq_num) {
     drop_msg_num += (msg->seq_num - seq_num);
-    seq_num = msg->seq_num;
+    seq_num = msg->seq_num + 1;
   } else {
     seq_num++;
   }

--- a/fabric_nodes/src/dummy_node.cpp
+++ b/fabric_nodes/src/dummy_node.cpp
@@ -276,6 +276,12 @@ void DummyNode::parse_subscribe_topic(const std::string & subscribe_prefix)
     auto publishers_info = this->get_publishers_info_by_topic(topic_oss.str());
     if (publishers_info.size() > 0) {
       auto qos = publishers_info[0].qos_profile();
+
+      // Account for FastRTPS which does not forward a correct HistoryProfile
+      if (qos.history() == rclcpp::HistoryPolicy::Unknown) {
+        qos = qos.keep_last(1);
+      }
+
       sub.subscriber = this->create_subscription<DummyMsgT>(topic_oss.str(), qos, cb, sub_options);
       break;
     }


### PR DESCRIPTION
Sorry this is a bit messy but here's what was done:
- Turn `get_log.py` into just a plain Python script (no ROS) because it doesn't need `rclpy`
- Remove unused `search_freq_bw_log` function in `get_log.py`
- Remove outlier filtering in `get_log.py` as this was causing many empty CSV files to be produced
- Fix a bug in dropped message counting
- Fix a problem caused by FastRTPS not forwarding the QoS profile from publishers (it is not required that the DDS provider does this, BTW, but Cyclone does it anyway)